### PR TITLE
Fix two issues.

### DIFF
--- a/DynamoDbSupplyCollector/DynamoDbDataLoader/SampleDataProvider.cs
+++ b/DynamoDbSupplyCollector/DynamoDbDataLoader/SampleDataProvider.cs
@@ -12,7 +12,10 @@ namespace DynamoDbDataLoader
 
             var noLastName = new Person() { Id = Guid.NewGuid(), FirstName = "Eugene" };
             var deleted = new Person() { Id = Guid.NewGuid(), FirstName = "Eugene (deleted)", IsDeleted = true };
+            var noType1 = new Person(1000000, 10, 10);
+            noType1.Addresses["type1"] = null;
 
+            list.Add(noType1);
             list.Add(noLastName);
             list.Add(deleted);
 

--- a/DynamoDbSupplyCollector/DynamoDbSupplyCollector.Tests/DynamoAttributeExtensionsTests.cs
+++ b/DynamoDbSupplyCollector/DynamoDbSupplyCollector.Tests/DynamoAttributeExtensionsTests.cs
@@ -23,21 +23,6 @@ namespace DynamoDbSupplyCollector.Tests
                     M = new Dictionary<string, AttributeValue>
                     {
                         {
-                            "type1", new AttributeValue
-                            {
-                                IsMSet = true,
-                                M = new Dictionary<string, AttributeValue>
-                                {
-                                    { "Zip", new AttributeValue { S = "Zip1" } },
-                                    { "Street2", new AttributeValue { S = "Street21" } },
-                                    { "Street1", new AttributeValue { S = "Street11" } },
-                                    { "City", new AttributeValue { S = "City1" } },
-                                    { "State", new AttributeValue { S = "State1" } },
-                                }
-                            }
-                        },
-
-                            {
                             "type0", new AttributeValue
                             {
                                 IsMSet = true,
@@ -51,7 +36,7 @@ namespace DynamoDbSupplyCollector.Tests
                                 }
                             }
                         }
-                    },
+                    }
                 }
             }
         };
@@ -186,10 +171,20 @@ namespace DynamoDbSupplyCollector.Tests
             var sample = _mapSut.CollectSample("Addresses.type0.Street1");
 
             // assert
-            var expected = "Street11";
+            var expected = "Street10";
 
             sample.Should().HaveCount(1);
             sample.First().Should().Be(expected);
+        }
+
+        [Fact]
+        public void CollectSample_nested_object_that_does_not_exist()
+        {
+            // act
+            var sample = _mapSut.CollectSample("Addresses.type1.Street1");
+
+            // assert
+            sample.Should().HaveCount(0);
         }
 
         [Fact]
@@ -205,12 +200,6 @@ namespace DynamoDbSupplyCollector.Tests
             // assert
             var expected = new List<DataEntity>()
             {
-                new DataEntity("Addresses.type1.Zip", DataType.String, "S", container, collection),
-                new DataEntity("Addresses.type1.Street2", DataType.String, "S", container, collection),
-                new DataEntity("Addresses.type1.Street1", DataType.String, "S", container, collection),
-                new DataEntity("Addresses.type1.City", DataType.String, "S", container, collection),
-                new DataEntity("Addresses.type1.State", DataType.String, "S", container, collection),
-
                 new DataEntity("Addresses.type0.Zip", DataType.String, "S", container, collection),
                 new DataEntity("Addresses.type0.Street2", DataType.String, "S", container, collection),
                 new DataEntity("Addresses.type0.Street1", DataType.String, "S", container, collection),
@@ -248,7 +237,7 @@ namespace DynamoDbSupplyCollector.Tests
             // arrange
             var container = new DataContainer();
             var collection = new DataCollection(container, "Any");
-           
+
             // act
             var schema = _simpleListsSut.GetSchema(container, collection);
 

--- a/DynamoDbSupplyCollector/DynamoDbSupplyCollector.Tests/DynamoDbSupplyCollectorTests.cs
+++ b/DynamoDbSupplyCollector/DynamoDbSupplyCollector.Tests/DynamoDbSupplyCollectorTests.cs
@@ -51,8 +51,8 @@ namespace DynamoDbSupplyCollector.Tests
             var (dataCollections, dataEntities) = _sut.GetSchema(_container);
 
             Action act = () => dataEntities
-                .Where(d => d.Name == "Addresses.type1.Street1")
-                .Select(d => _sut.CollectSample(d, dataEntities.Count)).ToList();
+                //.Where(d => d.Name == "Addresses.type1.Street1")
+                .Select(d => _sut.CollectSample(d, 500)).ToList();
 
             act.Should().NotThrow();
         }

--- a/DynamoDbSupplyCollector/DynamoDbSupplyCollector/DynamoDbSupplyCollector.cs
+++ b/DynamoDbSupplyCollector/DynamoDbSupplyCollector/DynamoDbSupplyCollector.cs
@@ -31,9 +31,9 @@ namespace DynamoDbSupplyCollector
                         Limit = (int)limit
                     };
 
-                    var response = client.ScanAsync(request).GetAwaiter().GetResult();
+                    var response = client.ScanAll(request).GetAwaiter().GetResult();
 
-                    return response.Items;
+                    return response;
                 });
 
                 var samples = datasource


### PR DESCRIPTION
1. Every document in DynamoDB might have a different structure (except indexed fields). So CollectSchema might return data entities that not every document has. This PR has some tests that reproduce this problem and a fix for it

2. I remembered that DynamoDB can return up to 1Mb of data at a time. So I added some extra logic to handle this limitation (see ScanAll method).  